### PR TITLE
feat(sidekick): エージェントペインをフローティングウィンドウに変更

### DIFF
--- a/.config/nvim/lua/plugins/sidekick.lua
+++ b/.config/nvim/lua/plugins/sidekick.lua
@@ -8,6 +8,9 @@ return {
 					backend = "tmux",
 					enabled = false,
 				},
+				win = {
+					layout = "float",
+				},
 			},
 		},
 		keys = {


### PR DESCRIPTION
cli.win.layout = "float" を設定し、サイドペインではなく
フローティングウィンドウでエージェントが表示されるようにした。

https://claude.ai/code/session_015fit5toCbiDaC3iGM9Jnk1